### PR TITLE
make reddit link go to correct page

### DIFF
--- a/src/components/RedditControls.js
+++ b/src/components/RedditControls.js
@@ -83,7 +83,7 @@ const RedditControls = (props) => {
           <Title>
             {currentVid && currentVid.media.oembed.title}
           </Title>
-          <Link href={currentVid && `https://www.reddit.com/${currentVid.permalink}`} target="_blank">
+          <Link href={currentVid && `https://www.reddit.com${currentVid.permalink}`} target="_blank">
             <Icon src={icons.reddit} alt="reddit-icon" />
           </Link>
         </TitleGroup>


### PR DESCRIPTION
now it goes to for example `https://www.reddit.com//r/videos/comments/5tc3mc/permanent_magnet_switch/`, with the / duplicated